### PR TITLE
Use pragmas for fill-color and fill-outline-color

### DIFF
--- a/src/circle.fragment.glsl
+++ b/src/circle.fragment.glsl
@@ -23,7 +23,7 @@ void main() {
     float t = smoothstep(1.0 - u_blur, 1.0, length(v_extrude));
     gl_FragColor = u_color * (1.0 - t) * u_opacity;
 #else
-    #pragma mapbox: initialize color
+    #pragma mapbox: initialize color lowp
 
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
     gl_FragColor = color * (1.0 - t) * u_opacity;

--- a/src/circle.vertex.glsl
+++ b/src/circle.vertex.glsl
@@ -33,8 +33,8 @@ varying lowp float v_antialiasblur;
 void main(void) {
 #ifdef MAPBOX_GL_JS
 
-    #pragma mapbox: initialize color
-    #pragma mapbox: initialize radius
+    #pragma mapbox: initialize color lowp
+    #pragma mapbox: initialize radius mediump
 
 #endif
     // unencode the extrusion vector that we snuck into the a_pos vector

--- a/src/fill.fragment.glsl
+++ b/src/fill.fragment.glsl
@@ -6,11 +6,13 @@ precision mediump float;
 #define highp
 #endif
 
-uniform lowp vec4 u_color;
 uniform lowp float u_opacity;
+#pragma mapbox: define color lowp
 
 void main() {
-    gl_FragColor = u_color * u_opacity;
+    #pragma mapbox: initialize color lowp
+
+    gl_FragColor = color * u_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/fill.fragment.glsl
+++ b/src/fill.fragment.glsl
@@ -6,11 +6,21 @@ precision mediump float;
 #define highp
 #endif
 
-uniform lowp float u_opacity;
+#ifdef MAPBOX_GL_JS
 #pragma mapbox: define color lowp
+#else
+uniform lowp vec4 u_color;
+#endif
+
+uniform lowp float u_opacity;
 
 void main() {
+
+#ifdef MAPBOX_GL_JS
     #pragma mapbox: initialize color lowp
+#else
+    lowp vec4 color = u_color;
+#endif
 
     gl_FragColor = color * u_opacity;
 

--- a/src/fill.vertex.glsl
+++ b/src/fill.vertex.glsl
@@ -10,9 +10,15 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+#ifdef MAPBOX_GL_JS
 #pragma mapbox: define color lowp
+#endif
 
 void main() {
+
+#ifdef MAPBOX_GL_JS
     #pragma mapbox: initialize color lowp
+#endif
+
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }

--- a/src/fill.vertex.glsl
+++ b/src/fill.vertex.glsl
@@ -10,6 +10,9 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+#pragma mapbox: define color lowp
+
 void main() {
+    #pragma mapbox: initialize color lowp
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }

--- a/src/outline.fragment.glsl
+++ b/src/outline.fragment.glsl
@@ -6,14 +6,23 @@ precision mediump float;
 #define highp
 #endif
 
+#ifdef MAPBOX_GL_JS
+#pragma mapbox: define outline_color lowp
+#else
+uniform lowp vec4 u_color;
+#endif
+
 uniform lowp float u_opacity;
 
 varying vec2 v_pos;
 
-#pragma mapbox: define outline_color lowp
-
 void main() {
+
+#ifdef MAPBOX_GL_JS
     #pragma mapbox: initialize outline_color lowp
+#else
+    lowp vec4 outline_color = u_color;
+#endif
 
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);

--- a/src/outline.fragment.glsl
+++ b/src/outline.fragment.glsl
@@ -6,15 +6,18 @@ precision mediump float;
 #define highp
 #endif
 
-uniform lowp vec4 u_color;
 uniform lowp float u_opacity;
 
 varying vec2 v_pos;
 
+#pragma mapbox: define outline_color lowp
+
 void main() {
+    #pragma mapbox: initialize outline_color lowp
+
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = smoothstep(1.0, 0.0, dist);
-    gl_FragColor = u_color * (alpha * u_opacity);
+    gl_FragColor = outline_color * (alpha * u_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/outline.vertex.glsl
+++ b/src/outline.vertex.glsl
@@ -13,10 +13,15 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
+#ifdef MAPBOX_GL_JS
 #pragma mapbox: define outline_color lowp
+#endif
+
 
 void main() {
+#ifdef MAPBOX_GL_JS
     #pragma mapbox: initialize outline_color lowp
+#endif
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;

--- a/src/outline.vertex.glsl
+++ b/src/outline.vertex.glsl
@@ -13,7 +13,11 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
+#pragma mapbox: define outline_color lowp
+
 void main() {
+    #pragma mapbox: initialize outline_color lowp
+
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
 }


### PR DESCRIPTION
:warning: **breaking changes** :warning: 
- rename outline shaders’ `color` attribute to `outline_color`
- require a precision argument for `initialize` pragmas as well as `define` pragmas
- use pragmas for fill color and outline color

cc @jfirebaugh 
