### PR TITLE
Update circle shader code for Mapbox GL native

### DIFF
--- a/src/circle.fragment.glsl
+++ b/src/circle.fragment.glsl
@@ -13,21 +13,20 @@ uniform lowp float u_opacity;
 uniform vec4 u_color;
 #else
 #pragma mapbox: define color lowp
-varying lowp float v_antialiasblur;
 #endif
+varying lowp float v_antialiasblur;
 
 varying vec2 v_extrude;
 
 void main() {
 #ifndef MAPBOX_GL_JS
-    float t = smoothstep(1.0 - u_blur, 1.0, length(v_extrude));
-    gl_FragColor = u_color * (1.0 - t) * u_opacity;
+    vec4 color = u_color;
 #else
     #pragma mapbox: initialize color lowp
+#endif
 
     float t = smoothstep(1.0 - max(u_blur, v_antialiasblur), 1.0, length(v_extrude));
     gl_FragColor = color * (1.0 - t) * u_opacity;
-#endif
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/circle.vertex.glsl
+++ b/src/circle.vertex.glsl
@@ -6,59 +6,39 @@ precision highp float;
 #define highp
 #endif
 
-#ifndef MAPBOX_GL_JS
-// set by gl_util
-uniform float u_size;
-#else
 uniform mat4 u_matrix;
 uniform vec2 u_extrude_scale;
 uniform float u_devicepixelratio;
-#endif
 
 attribute vec2 a_pos;
 
 #ifndef MAPBOX_GL_JS
-uniform mat4 u_matrix;
-uniform mat4 u_exmatrix;
+uniform float u_radius;
 #else
-#pragma mapbox: define color lowp
 #pragma mapbox: define radius mediump
 #endif
 
 varying vec2 v_extrude;
-#ifdef MAPBOX_GL_JS
 varying lowp float v_antialiasblur;
-#endif
 
 void main(void) {
-#ifdef MAPBOX_GL_JS
-
-    #pragma mapbox: initialize color lowp
+#ifndef MAPBOX_GL_JS
+    float radius = u_radius;
+#else
     #pragma mapbox: initialize radius mediump
-
 #endif
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);
 
-#ifndef MAPBOX_GL_JS
-    vec4 extrude = u_exmatrix * vec4(v_extrude * u_size, 0, 0);
-#else
     vec2 extrude = v_extrude * radius * u_extrude_scale;
-#endif
     // multiply a_pos by 0.5, since we had it * 2 in order to sneak
     // in extrusion data
     gl_Position = u_matrix * vec4(floor(a_pos * 0.5), 0, 1);
 
-#ifndef MAPBOX_GL_JS
-    // gl_Position is divided by gl_Position.w after this shader runs.
-    // Multiply the extrude by it so that it isn't affected by it.
-    gl_Position += extrude * gl_Position.w;
-#else
     gl_Position.xy += extrude;
 
     // This is a minimum blur distance that serves as a faux-antialiasing for
     // the circle. since blur is a ratio of the circle's size and the intent is
     // to keep the blur at roughly 1px, the two are inversely related.
     v_antialiasblur = 1.0 / u_devicepixelratio / radius;
-#endif
 }


### PR DESCRIPTION
Ported the following patches:
- [convert mat4 exMatrix to a vec2 extrudeScale](https://github.com/mapbox/mapbox-gl-shaders/commit/a8d549b7a41540d3a99767975ff1b7b18a6010e9)
- [Enabled data-driven styling for circle-radius](https://github.com/mapbox/mapbox-gl-shaders/commit/4356e41fa657837904d189e604468617ee601ddb)
- [Reduce shader boilerplate, refactor "Bucket"](https://github.com/mapbox/mapbox-gl-shaders/commit/7d3da8f1914954fd96f305b7116cfd127a616551)

Part of #1.

Getting rid of all #ifdefs in circle shader depends on https://github.com/mapbox/mapbox-gl-native/issues/5174.

/cc @lucaswoj @jfirebaugh @kkaefer @ansis 
