### PR TITLE
Update {icon,sdf} shader code for Mapbox GL native

### DIFF
--- a/src/icon.vertex.glsl
+++ b/src/icon.vertex.glsl
@@ -12,19 +12,12 @@ attribute vec4 a_data1;
 attribute vec4 a_data2;
 
 
-// matrix is for the vertex position, exmatrix is for rotating and projecting
-// the extrusion vector.
+// matrix is for the vertex position.
 uniform mat4 u_matrix;
-#ifndef MAPBOX_GL_JS
-uniform mat4 u_exmatrix;
-#endif
 
 uniform mediump float u_zoom;
 uniform bool u_skewed;
-uniform float u_extra;
-#ifdef MAPBOX_GL_JS
 uniform vec2 u_extrude_scale;
-#endif
 
 uniform vec2 u_texsize;
 
@@ -41,24 +34,12 @@ void main() {
     // u_zoom is the current zoom level adjusted for the change in font size
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
 
-#ifdef MAPBOX_GL_JS
     vec2 extrude = u_extrude_scale * (a_offset / 64.0);
-#endif
     if (u_skewed) {
-#ifndef MAPBOX_GL_JS
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, 0, 0);
-        gl_Position = u_matrix * vec4(a_pos + extrude.xy, 0, 1);
-#else
         gl_Position = u_matrix * vec4(a_pos + extrude, 0, 1);
-#endif
         gl_Position.z += z * gl_Position.w;
     } else {
-#ifndef MAPBOX_GL_JS
-        vec4 extrude = u_exmatrix * vec4(a_offset / 64.0, z, 0);
-        gl_Position = u_matrix * vec4(a_pos, 0, 1) + extrude;
-#else
         gl_Position = u_matrix * vec4(a_pos, 0, 1) + vec4(extrude, 0, 0);
-#endif
     }
 
     v_tex = a_tex / u_texsize;

--- a/src/sdf.vertex.glsl
+++ b/src/sdf.vertex.glsl
@@ -12,18 +12,12 @@ attribute vec4 a_data1;
 attribute vec4 a_data2;
 
 
-// matrix is for the vertex position, exmatrix is for rotating and projecting
-// the extrusion vector.
+// matrix is for the vertex position.
 uniform mat4 u_matrix;
-#ifndef MAPBOX_GL_JS
-uniform mat4 u_exmatrix;
-#endif
 
 uniform mediump float u_zoom;
 uniform bool u_skewed;
-#ifdef MAPBOX_GL_JS
 uniform vec2 u_extrude_scale;
-#endif
 
 uniform vec2 u_texsize;
 
@@ -39,30 +33,14 @@ void main() {
     mediump float a_maxzoom = a_zoom[1];
 
     // u_zoom is the current zoom level adjusted for the change in font size
-#ifndef MAPBOX_GL_JS
-    float show = step(a_minzoom, u_zoom) * (1.0 - step(a_maxzoom, u_zoom));
-#else
     mediump float z = 2.0 - step(a_minzoom, u_zoom) - (1.0 - step(a_maxzoom, u_zoom));
-#endif
 
-#ifdef MAPBOX_GL_JS
     vec2 extrude = u_extrude_scale * (a_offset / 64.0);
-#endif
     if (u_skewed) {
-#ifndef MAPBOX_GL_JS
-        vec4 extrude = u_exmatrix * vec4(a_offset * show / 64.0, 0, 0);
-        gl_Position = u_matrix * vec4(a_pos + extrude.xy, 0, 1);
-#else
         gl_Position = u_matrix * vec4(a_pos + extrude, 0, 1);
         gl_Position.z += z * gl_Position.w;
-#endif
     } else {
-#ifndef MAPBOX_GL_JS
-        vec4 extrude = u_exmatrix * vec4(a_offset * show / 64.0, 0, 0);
-        gl_Position = u_matrix * vec4(a_pos, 0, 1) + extrude;
-#else
         gl_Position = u_matrix * vec4(a_pos, 0, 1) + vec4(extrude, 0, 0);
-#endif
     }
 
     v_gamma_scale = (gl_Position.w - 0.5);


### PR DESCRIPTION
Ported the following patch:
- [convert mat4 exMatrix to a vec2 extrudeScale](https://github.com/mapbox/mapbox-gl-shaders/commit/a8d549b7a41540d3a99767975ff1b7b18a6010e9)

Part of #1.

/cc @lucaswoj @jfirebaugh @kkaefer @ansis
