### PR TITLE
Revert changes to shaders that broke gl js

### DIFF
--- a/src/circle.vertex.glsl
+++ b/src/circle.vertex.glsl
@@ -12,12 +12,14 @@ uniform float u_devicepixelratio;
 
 attribute vec2 a_pos;
 
+#pragma mapbox: define color lowp
 #pragma mapbox: define radius mediump
 
 varying vec2 v_extrude;
 varying lowp float v_antialiasblur;
 
 void main(void) {
+    #pragma mapbox: initialize color lowp
     #pragma mapbox: initialize radius mediump
     // unencode the extrusion vector that we snuck into the a_pos vector
     v_extrude = vec2(mod(a_pos, 2.0) * 2.0 - 1.0);

--- a/src/fill.vertex.glsl
+++ b/src/fill.vertex.glsl
@@ -10,6 +10,9 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+#pragma mapbox: define color lowp
+
 void main() {
+    #pragma mapbox: initialize color lowp
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
 }

--- a/src/outline.vertex.glsl
+++ b/src/outline.vertex.glsl
@@ -13,7 +13,11 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
+#pragma mapbox: define outline_color lowp
+
 void main() {
+    #pragma mapbox: initialize outline_color lowp
+
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
 }


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-shaders/pull/6/files#r65579366, reintroduces removed pragma statements needed by GL JS.
### Next actions
- [x] tests passing on GL JS + [PR](https://github.com/mapbox/mapbox-gl-js/pull/2679)
- [x] tests passing on GL Native + [PR](https://github.com/mapbox/mapbox-gl-native/pull/5261)
- [x] review from @lucaswoj @brunoabinader 
