### PR TITLE
[not ready] Extrusion vertex shaders: remove minH in z-axis gradient calculation

### DIFF
--- a/src/fill_extrude.vertex.glsl
+++ b/src/fill_extrude.vertex.glsl
@@ -64,7 +64,7 @@ void main() {
 
     // Add gradient along z axis of side surfaces
     if (a_normal.y != 0.0) {
-        directional *= clamp(t * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp((t + minH) * pow(maxH, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     // Assign final color based on surface + ambient light color, diffuse light directional, and light color

--- a/src/fill_extrude.vertex.glsl
+++ b/src/fill_extrude.vertex.glsl
@@ -64,7 +64,7 @@ void main() {
 
     // Add gradient along z axis of side surfaces
     if (a_normal.y != 0.0) {
-        directional *= clamp((t + minH) * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp(t * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     // Assign final color based on surface + ambient light color, diffuse light directional, and light color

--- a/src/fill_extrude_pattern.vertex.glsl
+++ b/src/fill_extrude_pattern.vertex.glsl
@@ -75,7 +75,7 @@ void main() {
     directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
 
     if (a_normal.y != 0.0) {
-        directional *= clamp(t * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp((t + minH) * pow(maxH, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));

--- a/src/fill_extrude_pattern.vertex.glsl
+++ b/src/fill_extrude_pattern.vertex.glsl
@@ -75,7 +75,7 @@ void main() {
     directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
 
     if (a_normal.y != 0.0) {
-        directional *= clamp((t + minH) * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp(t * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));


### PR DESCRIPTION
Fixes this issue:

![2016-10-14 at 1 28 pm](https://cloud.githubusercontent.com/assets/5607844/19401255/49a6feaa-9228-11e6-96e1-6f0e9fc2fa97.png)

I'm not sure at what point `minH` got integrated into this calculation in the first place, but I don't see any issues with removing it. 

**This branch still needs testing.**
