### PR TITLE
Extrusion shader cleanup

### DIFF
--- a/src/fill_extrusion.fragment.glsl
+++ b/src/fill_extrusion.fragment.glsl
@@ -7,17 +7,13 @@ precision mediump float;
 #endif
 
 varying vec4 v_color;
-#ifdef MAPBOX_GL_JS
-#pragma mapbox: define lowp float minH
-#pragma mapbox: define lowp float maxH
-#endif
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
 #pragma mapbox: define lowp vec4 color
 
 void main() {
-#ifdef MAPBOX_GL_JS
-    #pragma mapbox: initialize lowp float minH
-    #pragma mapbox: initialize lowp float maxH
-#endif
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
     #pragma mapbox: initialize lowp vec4 color
 
     gl_FragColor = v_color;

--- a/src/fill_extrusion.vertex.glsl
+++ b/src/fill_extrusion.vertex.glsl
@@ -18,27 +18,20 @@ attribute float a_edgedistance;
 
 varying vec4 v_color;
 
-#ifndef MAPBOX_GL_JS
-attribute float minH;
-attribute float maxH;
-#else
-#pragma mapbox: define lowp float minH
-#pragma mapbox: define lowp float maxH
-#endif
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
 
 #pragma mapbox: define lowp vec4 color
 
 void main() {
-#ifdef MAPBOX_GL_JS
-    #pragma mapbox: initialize lowp float minH
-    #pragma mapbox: initialize lowp float maxH
-#endif
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
     #pragma mapbox: initialize lowp vec4 color
 
     float ed = a_edgedistance; // use each attrib in order to not trip a VAO assert
     float t = mod(a_normal.x, 2.0);
 
-    gl_Position = u_matrix * vec4(a_pos, t > 0.0 ? maxH : minH, 1);
+    gl_Position = u_matrix * vec4(a_pos, t > 0.0 ? height : base, 1);
 
 #ifdef OUTLINE
     color = u_outline_color;
@@ -64,7 +57,7 @@ void main() {
 
     // Add gradient along z axis of side surfaces
     if (a_normal.y != 0.0) {
-        directional *= clamp((t + minH) * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     // Assign final color based on surface + ambient light color, diffuse light directional, and light color

--- a/src/fill_extrusion_pattern.fragment.glsl
+++ b/src/fill_extrusion_pattern.fragment.glsl
@@ -18,18 +18,12 @@ varying vec2 v_pos_a;
 varying vec2 v_pos_b;
 varying vec4 v_lighting;
 
-#ifdef MAPBOX_GL_JS
-#pragma mapbox: define lowp float minH
-#pragma mapbox: define lowp float maxH
-#endif
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
 
 void main() {
-#ifdef MAPBOX_GL_JS
-    #pragma mapbox: initialize lowp float minH
-    #pragma mapbox: initialize lowp float maxH
-#endif
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
 
     vec2 imagecoord = mod(v_pos_a, 1.0);
     vec2 pos = mix(u_pattern_tl_a, u_pattern_br_a, imagecoord);

--- a/src/fill_extrusion_pattern.vertex.glsl
+++ b/src/fill_extrusion_pattern.vertex.glsl
@@ -29,25 +29,15 @@ varying vec2 v_pos_b;
 varying vec4 v_lighting;
 varying float v_directional;
 
-#ifndef MAPBOX_GL_JS
-attribute float minH;
-attribute float maxH;
-#else
-#pragma mapbox: define lowp float minH
-#pragma mapbox: define lowp float maxH
-#endif
-
-#pragma mapbox: define lowp vec4 color
+#pragma mapbox: define lowp float base
+#pragma mapbox: define lowp float height
 
 void main() {
-#ifdef MAPBOX_GL_JS
-    #pragma mapbox: initialize lowp float minH
-    #pragma mapbox: initialize lowp float maxH
-#endif
-    #pragma mapbox: initialize lowp vec4 color
+    #pragma mapbox: initialize lowp float base
+    #pragma mapbox: initialize lowp float height
 
     float t = mod(a_normal.x, 2.0);
-    float z = t > 0.0 ? maxH : minH;
+    float z = t > 0.0 ? height : base;
 
     gl_Position = u_matrix * vec4(a_pos, z, 1);
 
@@ -75,7 +65,7 @@ void main() {
     directional = mix((1.0 - u_lightintensity), max((0.5 + u_lightintensity), 1.0), directional);
 
     if (a_normal.y != 0.0) {
-        directional *= clamp((t + minH) * pow(maxH / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
+        directional *= clamp((t + base) * pow(height / 150.0, 0.5), mix(0.7, 0.98, 1.0 - u_lightintensity), 1.0);
     }
 
     v_lighting.rgb += clamp(directional * u_lightcolor, mix(vec3(0.0), vec3(0.3), 1.0 - u_lightcolor), vec3(1.0));


### PR DESCRIPTION
* Remove unnecessary IFDEFS
* Rename a_minH to a_base and a_maxH to a_height for naming consistency
* Remove unused color attributes from fill_extrusion_pattern shaders

@mourner @jfirebaugh 