### PR TITLE
Avoid redefining precision macros

### DIFF
--- a/src/_prelude.fragment.glsl
+++ b/src/_prelude.fragment.glsl
@@ -1,7 +1,17 @@
 #ifdef GL_ES
 precision mediump float;
 #else
+
+#if !defined(lowp)
 #define lowp
+#endif
+
+#if !defined(mediump)
 #define mediump
+#endif
+
+#if !defined(highp)
 #define highp
+#endif
+
 #endif

--- a/src/_prelude.vertex.glsl
+++ b/src/_prelude.vertex.glsl
@@ -1,9 +1,19 @@
 #ifdef GL_ES
 precision highp float;
 #else
+
+#if !defined(lowp)
 #define lowp
+#endif
+
+#if !defined(mediump)
 #define mediump
+#endif
+
+#if !defined(highp)
 #define highp
+#endif
+
 #endif
 
 float evaluate_zoom_function_1(const vec4 values, const float t) {


### PR DESCRIPTION
This fixes an issue where some non-conforming GLSL compilers predefines precision macros for `lowp`, `mediump` and `highp` for non-GLSL ES code.

Refs: https://github.com/mapbox/mapbox-gl-native/issues/2995 and https://github.com/mapbox/mapbox-gl-native/issues/6400.